### PR TITLE
Update plugin for TF2 models support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,7 @@ Keras `.h5 models`:
 
 ### Convert saved model to ONNX macro
 
-1. (If you don't already have one) create a DSS python3 code environment 
-with the following packages (i.e. packages needed for Visual Deep Learning with keras==2.1.6):
-```tensorflow==1.8.0
-keras==2.1.6
-scikit-learn>=0.20,<0.21
-scipy>=1.1,<1.2
-statsmodels>=0.9,<0.10
-jinja2>=2.10,<2.11
-flask>=1.0,<1.1
-h5py==2.7.1
-pillow==5.1.0
-```
-
+1. (If you don't already have one) create a DSS python3 code environment, adding to it the Visual Deep Learning packages preset.
 2. Train a Visual Deep learning model in DSS with this code environment ([here](https://academy.dataiku.com/introduction-to-deep-learning-with-code-open/513277) is a tutorial to help you get started)
 3. Install this plugin
 4. Go the flow
@@ -109,19 +97,7 @@ The macros are also available in the `Macro` menu of a project.
 
 ### Convert saved model to ONNX recipe
 
-1. Create (if you don't already have one) a DSS python3 code env 
-with the following packages (i.e. packages needed for Visual Deep Learning with keras==2.1.6):
-```tensorflow==1.8.0
-keras==2.1.6
-scikit-learn>=0.20,<0.21
-scipy>=1.1,<1.2
-statsmodels>=0.9,<0.10
-jinja2>=2.10,<2.11
-flask>=1.0,<1.1
-h5py==2.7.1
-pillow==5.1.0
-```
-
+1. Create (if you don't already have one) a DSS python3 code environment, adding to it the Visual Deep Learning packages preset.
 2. Train a Visual Deep learning model in DSS with this code env
 3. Create a managed folder by clicking on `+ DATASET > Folder`
 4. Install this plugin

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -2,6 +2,6 @@
   "acceptedPythonInterpreters": ["PYTHON37","PYTHON38","PYTHON39"],
   "forceConda": false,
   "installCorePackages": true,
-  "corePackagesSet": "PANDAS10",
+  "corePackagesSet": "PANDAS11",
   "installJupyterSupport": false
 }

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON36", "PYTHON35", "PYTHON34"],
+  "acceptedPythonInterpreters": ["PYTHON37"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,6 +1,7 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON37"],
+  "acceptedPythonInterpreters": ["PYTHON37","PYTHON38","PYTHON39"],
   "forceConda": false,
   "installCorePackages": true,
+  "corePackagesSet": "PANDAS10",
   "installJupyterSupport": false
 }

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,4 +1,4 @@
 tf2onnx==1.10.1
 tensorflow>=2.6,<3.0
 h5py==3.1.0
-scikit-learn>=0.20,<0.21
+scikit-learn>=1.0,<1.1

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,6 +1,4 @@
-tensorflow>=1.5.0,<2.0.0
-keras>=2.1.6, <=2.3.1
-h5py==2.10.0
+tf2onnx==1.10.1
+tensorflow>=2.6,<3.0
+h5py==3.1.0
 scikit-learn>=0.20,<0.21
-keras2onnx==1.6.1
-onnx==1.6.0

--- a/python-runnables/exporter/runnable.py
+++ b/python-runnables/exporter/runnable.py
@@ -47,7 +47,7 @@ class MyRunnable(Runnable):
 
     def run(self, progress_callback):
         """
-        Gets a saved model, converts it with keras2onnx, saves it back in the folder, builds a url for the download
+        Gets a saved model, converts it with tf2onnx, saves it back in the folder, builds a url for the download
         """
         
         keras_model = get_keras_model_from_saved_model(self.project_key, self.model)

--- a/python-runnables/h5-exporter/runnable.py
+++ b/python-runnables/h5-exporter/runnable.py
@@ -34,7 +34,7 @@ class MyRunnable(Runnable):
 
     def run(self, progress_callback):
         """
-        Loads a h5 file, converts it with keras2onnx, saves it back in the folder, builds a url for the download
+        Loads a h5 file, converts it with tf2onnx, saves it back in the folder, builds a url for the download
         """
         check_keras_version(self.input_folder, self.model_path)
         keras_model = get_keras_model_from_folder(self.input_folder, self.model_path)


### PR DESCRIPTION
Replace keras2onnx with tf2onnx, and handle cross-version compatible calls
to have tf1 and tf2 models support.
Update README to reference up-to-date DSS presets instead of a static package listing.