### PR TITLE
[Release 1.2.0] Support for python 3.10 & small UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 1.2.0](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.2.0) - Bugfix release - 2022-06
+## [Version 1.2.0](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.2.0) - Bugfix release - 2023-04
 
 - [Enhancement] Add support for python 3.10
 - [Enhancement] Bump h5py version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Version 1.1.0](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.2.0) - Bugfix release - 2022-06
 
-- [Enhancement] Add support for recent python versions (3.10, 3.11)
+- [Enhancement] Add support for python 3.10
 - [Enhancement] Bump h5py version
 - [Fix] Setting default values of some form params for recipes & macros in the UI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 1.1.0](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.2.0) - Bugfix release - 2022-06
+## [Version 1.2.0](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.2.0) - Bugfix release - 2022-06
 
 - [Enhancement] Add support for python 3.10
 - [Enhancement] Bump h5py version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Version 1.1.0](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.2.0) - Bugfix release - 2022-06
+
+- [Enhancement] Add support for recent python versions (3.10, 3.11)
+- [Enhancement] Bump h5py version
+- [Fix] Setting default values of some form params for recipes & macros in the UI
 
 ## [Version 1.1.0](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.1.0) - Bugfix release - 2022-06
 

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,7 +1,7 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON37","PYTHON38","PYTHON39"],
+  "acceptedPythonInterpreters": ["PYTHON37","PYTHON38","PYTHON39", "PYTHON310", "PYTHON311"],
   "forceConda": false,
   "installCorePackages": true,
-  "corePackagesSet": "PANDAS11",
+  "corePackagesSet": "AUTO",
   "installJupyterSupport": false
 }

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON37","PYTHON38","PYTHON39", "PYTHON310", "PYTHON311"],
+  "acceptedPythonInterpreters": ["PYTHON37","PYTHON38","PYTHON39", "PYTHON310"],
   "forceConda": false,
   "installCorePackages": true,
   "corePackagesSet": "AUTO",

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,4 +1,4 @@
 tf2onnx==1.10.1
 tensorflow>=2.6,<3.0
-h5py==3.1.0
+h5py==3.7.0
 scikit-learn>=1.0,<1.1

--- a/js/app.js
+++ b/js/app.js
@@ -4,7 +4,9 @@ app.controller('h5MacroController', function($scope) {
     var updateChoices = function() {
         $scope.callPythonDo({}).then(function(data) {
             $scope.model_path_choices = data.choices;
-            $scope.config.model_path = $scope.model_path_choices[0].value
+            if (!$scope.config.model_path) { // Set default value if none already set
+                $scope.config.model_path = $scope.model_path_choices[0].value
+            }
         }, function(data) {
             $scope.choices = [];
         });
@@ -28,22 +30,19 @@ app.controller('h5MacroController', function($scope) {
     }
     fetchAccessibleFolders();
     updateChoices();
-    
-    $scope.config.output_folder_id = undefined;
     $scope.templatePath = $scope.templateUrl.substring(0, $scope.templateUrl.lastIndexOf("/")+1);
-    $scope.config.batch_size = 50;
-    $scope.config.float_32 = true;
     
     $scope.$watch('config.input_folder_id', updateChoices, true);
     $scope.$watch('config.model_path', updateOutputModelPath, true);
-    
 });
 
 app.controller('h5RecipeController', function($scope) {
     var updateChoices = function() {
         $scope.callPythonDo({}).then(function(data) {
             $scope.model_path_choices = data.choices;
-            $scope.config.model_path = $scope.model_path_choices[0].value
+            if (!$scope.config.model_path) { // Set default value if none already set
+                $scope.config.model_path = $scope.model_path_choices[0].value
+            }
         }, function(data) {
             $scope.choices = [];
         });
@@ -57,8 +56,6 @@ app.controller('h5RecipeController', function($scope) {
 
     updateChoices();
     
-    $scope.config.batch_size = 50;
-    $scope.config.float_32 = true;
     $scope.templatePath = $scope.templateUrl.substring(0, $scope.templateUrl.lastIndexOf("/")+1);
     
     $scope.$watch('config.model_path', updateOutputModelPath, true);

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "onnx-exporter",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "meta": {
         "label": "ONNX exporter",
         "description": "Plugin to export Deep Learning models to ONNX format",


### PR DESCRIPTION
This PR:
* [sc-132139] adds support for python 3.10. This requires to bump the version of h5py. No noticeable change has been identified on the package changelog. For now, the support is limited to 3.10 because 3.11 would require much more work and will be done later.
* [sc-134297] fixes small UI bugs regarding values of the form for some of the plugin recipes.