### PR TITLE
Revert "Only accepts ML saved models inputs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## [Version 1.2.2](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.2.2) - Bugfix release - 2026-01
-
-- [Fix] Only accepts ML saved models
-
 ## [Version 1.2.1](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.2.1) - Bugfix release - 2025-06
 
 - [Fix] Bump tf2onnx
@@ -23,3 +19,5 @@
 - [Fix] Change import of constants to work with Dataiku 10
 
 ## [Version 1.0.0](https://github.com/dataiku/dss-plugin-onnx-exporter/releases/tag/v1.0.0) - Initial release - 2020-08
+
+

--- a/custom-recipes/onnx-exporter-convert-saved-model/recipe.json
+++ b/custom-recipes/onnx-exporter-convert-saved-model/recipe.json
@@ -4,7 +4,7 @@
         "icon": "icon-cloud-download"
     },
     "kind": "PYTHON",
-    "selectableFromMLModel" : "saved_model_id",
+    "selectableFromSavedModel" : "saved_model_id",
     "inputRoles": [
         {
             "name": "saved_model_id",
@@ -13,9 +13,9 @@
             "arity": "UNARY",
             "required": true,
             "acceptsDataset" : false,
-            "acceptsMLModel": true
+            "acceptsSavedModel": true
         }
-
+     
     ],
 
     "outputRoles": [
@@ -28,7 +28,7 @@
             "acceptsDataset" : false,
             "acceptsManagedFolder": true
         }
-
+        
     ],
 
     "params": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "onnx-exporter",
-    "version": "1.2.2",
+    "version": "1.2.1",
     "meta": {
         "label": "ONNX exporter",
         "description": "Plugin to export Deep Learning models to ONNX format",


### PR DESCRIPTION
Reverts dataiku/dss-plugin-onnx-exporter#8

It breaks on old DSS version, we need a new plugin store